### PR TITLE
Added legacy-peer-deps to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:latest
 
 RUN mkdir -p /var/www
-RUN npm install -g webpack-dev-server webpack
+RUN npm install -g webpack-dev-server webpack --legacy-peer-deps
 
 WORKDIR /var/www
 


### PR DESCRIPTION
Laest node:latest uses npm version 7.0.8 this is the only way to fix this. 
